### PR TITLE
fix register step npe

### DIFF
--- a/src/main/java/org/b3log/symphony/processor/LoginProcessor.java
+++ b/src/main/java/org/b3log/symphony/processor/LoginProcessor.java
@@ -488,7 +488,7 @@ public class LoginProcessor {
      */
     public void register(final RequestContext context) {
         context.renderJSON();
-        final JSONObject requestJSONObject = (JSONObject) context.attr(Keys.REQUEST);
+        final JSONObject requestJSONObject = context.getRequest().getJSON();
         final String name = requestJSONObject.optString(User.USER_NAME);
         final String email = requestJSONObject.optString(User.USER_EMAIL);
         final String invitecode = requestJSONObject.optString(Invitecode.INVITECODE);
@@ -547,7 +547,7 @@ public class LoginProcessor {
 
         final Request request = context.getRequest();
         final Response response = context.getResponse();
-        final JSONObject requestJSONObject = (JSONObject) context.attr(Keys.REQUEST);
+        final JSONObject requestJSONObject = context.getRequest().getJSON();
 
         final String password = requestJSONObject.optString(User.USER_PASSWORD); // Hashed
         final int appRole = requestJSONObject.optInt(UserExt.USER_APP_ROLE);


### PR DESCRIPTION
```
 final Request request = context.getRequest();
        final Response response = context.getResponse();
        //final JSONObject requestJSONObject = (JSONObject) context.attr(Keys.REQUEST);
        final JSONObject requestJSONObject = context.getRequest().getJSON();
```
LoginProcessor这段代码，在进行step 1 step2 阶段注册时，如果使用注释的那行将NPE，通过断点发现`context.getRequest().getJSON()`能够拿到正确的body 参数。
烦请请D大确认