### PR TITLE
Ignoring unnecessarily generated test-classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pci
+          mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pci -Dmaven.test.skip=true


### PR DESCRIPTION
In our analysis, we observe that target/test-classes is generated but not used in CI. Because this test-classes are not accessed after its generation, we propose to disable the generation of this directories to save runtime. The generation of this directory can be disabled by simply adding  -Dmaven.test.skip=true command. 