### PR TITLE
修复热重载功能

### DIFF
--- a/src/main/java/org/b3log/symphony/util/Templates.java
+++ b/src/main/java/org/b3log/symphony/util/Templates.java
@@ -57,25 +57,24 @@ public final class Templates {
         TEMPLATE_CFG.setDefaultEncoding("UTF-8");
         try {
             String path = Templates.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
-            LOGGER.info("Code source path: " + path);
-            LOGGER.info("Initial resource path: " + path); // 添加调试信息
+            LOGGER.log(Level.DEBUG, "Code source path: " + path);
             if (StringUtils.contains(path, "/target/classes/") || StringUtils.contains(path, "/target/test-classes/")) {
                 // 开发时使用源码目录
                 path = StringUtils.replace(path, "/target/classes/", "/src/main/resources/");
                 path = StringUtils.replace(path, "/target/test-classes/", "/src/main/resources/");
-                LOGGER.info("Adjusted resource path for development environment: " + path); // 添加调试信息
+                LOGGER.log(Level.DEBUG, "Adjusted resource path for development environment: " + path); // 添加调试信息
             }
             if (StringUtils.contains(path, "/target/symphony/")) {
                 // 开发时使用源码目录
                 path = StringUtils.replace(path, "/target/symphony/", "/src/main/resources/");
-                LOGGER.info("Adjusted resource path for development environment: " + path); // 添加调试信息
+                LOGGER.log(Level.DEBUG, "Adjusted resource path for development environment: " + path); // 添加调试信息
             }
             path += "skins";
             TEMPLATE_CFG.setDirectoryForTemplateLoading(new File(path));
             LOGGER.log(Level.INFO, "Loaded template from directory [" + path + "]");
         } catch (final Exception e) {
             TEMPLATE_CFG.setClassForTemplateLoading(Templates.class, "/skins");
-            LOGGER.error("Failed to load template from directory, loading from classpath", e); // 记录错误信息
+            LOGGER.log(Level.INFO, "Failed to load template from directory, loading from classpath", e); // 记录错误信息
         }
         TEMPLATE_CFG.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         TEMPLATE_CFG.setLogTemplateExceptions(false);

--- a/src/main/java/org/b3log/symphony/util/Templates.java
+++ b/src/main/java/org/b3log/symphony/util/Templates.java
@@ -56,18 +56,26 @@ public final class Templates {
         TEMPLATE_CFG = new Configuration(FREEMARKER_VER);
         TEMPLATE_CFG.setDefaultEncoding("UTF-8");
         try {
-            String path = Templates.class.getResource("/").getPath();
+            String path = Templates.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
+            LOGGER.info("Code source path: " + path);
+            LOGGER.info("Initial resource path: " + path); // 添加调试信息
             if (StringUtils.contains(path, "/target/classes/") || StringUtils.contains(path, "/target/test-classes/")) {
                 // 开发时使用源码目录
                 path = StringUtils.replace(path, "/target/classes/", "/src/main/resources/");
                 path = StringUtils.replace(path, "/target/test-classes/", "/src/main/resources/");
+                LOGGER.info("Adjusted resource path for development environment: " + path); // 添加调试信息
+            }
+            if (StringUtils.contains(path, "/target/symphony/")) {
+                // 开发时使用源码目录
+                path = StringUtils.replace(path, "/target/symphony/", "/src/main/resources/");
+                LOGGER.info("Adjusted resource path for development environment: " + path); // 添加调试信息
             }
             path += "skins";
             TEMPLATE_CFG.setDirectoryForTemplateLoading(new File(path));
             LOGGER.log(Level.INFO, "Loaded template from directory [" + path + "]");
         } catch (final Exception e) {
             TEMPLATE_CFG.setClassForTemplateLoading(Templates.class, "/skins");
-            LOGGER.log(Level.INFO, "Loaded template from classpath");
+            LOGGER.error("Failed to load template from directory, loading from classpath", e); // 记录错误信息
         }
         TEMPLATE_CFG.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         TEMPLATE_CFG.setLogTemplateExceptions(false);


### PR DESCRIPTION
未修改前idea可以热重载，但是命令行不行，因为
1.在打包后的应用中，资源文件（如模板文件）被打包进了 JAR 文件，因此不能使用常规的文件系统路径来访问它们，因此Templates.java的path获取方式有问题，以下是报错：
```
[ERROR]-[2023-11-15 09:38:37]-[org.b3log.symphony.util.Templates:72]: Failed to load template from directory, loading from classpath
java.io.FileNotFoundException: file:\E:\program\symphony\target\symphony\lib\HikariCP-5.0.1.jar!\META-INF\versions\11\skins does not exist.    
```

2.还有一个问题，就是应该替换/target/symphony/目录而不是/target/classes/

