### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
       - name: Build with Maven
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
         <testng.version>6.14.3</testng.version>
 
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Upgrades the build from Java 11 to Java 17 (LTS).

- `pom.xml`: `maven.compiler.source`/`maven.compiler.target` 11 → 17
- `.github/workflows/ci.yml`: `java-version` 11 → 17 so CI builds on the new target

**Verification:** the project compiles under JDK 17 and its unit tests pass, with none lost versus the JDK-11 baseline. (Tests requiring a running database were not executed locally and are unchanged.) No production or test code was modified — only the compiler target and the CI JDK.
